### PR TITLE
Add Docker and Docker Compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# syntax=docker/dockerfile:1
+
+# Old .NET docker images: https://devblogs.microsoft.com/dotnet/net-core-2-1-container-images-will-be-deleted-from-docker-hub/
+# 2.0 is not available so we are pointing to 2.1 to see if that works.
+# Or try this: https://github.com/dotnet/dotnet-docker/issues/279#issuecomment-322671257
+FROM mcr.microsoft.com/dotnet/sdk:2.1 as build-env
+WORKDIR /src
+COPY *.csproj .
+RUN dotnet restore
+COPY . .
+RUN dotnet publish -c Release -o /publish
+
+# FROM mcr.microsoft.com/dotnet/aspnet:2.1 as runtime
+# WORKDIR /publish
+# COPY --from=build-env /publish .
+EXPOSE 80
+ENTRYPOINT ["dotnet", "run"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,12 @@
 
 # Old .NET docker images: https://devblogs.microsoft.com/dotnet/net-core-2-1-container-images-will-be-deleted-from-docker-hub/
 # 2.0 is not available so we are pointing to 2.1 to see if that works.
-# Or try this: https://github.com/dotnet/dotnet-docker/issues/279#issuecomment-322671257
 FROM mcr.microsoft.com/dotnet/sdk:2.1 as build-env
 WORKDIR /src
 COPY *.csproj .
 RUN dotnet restore
 COPY . .
 RUN dotnet publish -c Release -o /publish
-
-# FROM mcr.microsoft.com/dotnet/aspnet:2.1 as runtime
-# WORKDIR /publish
-# COPY --from=build-env /publish .
+LABEL name="vulnerable-core-app"
 EXPOSE 80
 ENTRYPOINT ["dotnet", "run"]

--- a/README.md
+++ b/README.md
@@ -12,6 +12,21 @@ $ dotnet run
 
 Browse to http://localhost:5000
 
+# Docker
+
+Build with Docker:
+
+```bash
+docker build -t vulnerable-core-app .
+docker run -d -p 5000:80 --name vulnerable-core-app vulnerable-core-app
+```
+
+Alternatively, you can build and run with Docker Compose:
+
+```bash
+docker-compose up -d
+```
+
 # Examples
 
 ## Stored XSS

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.9'
+
+services:
+  core-app:
+    container_name: vulnerable-core-app
+    ports:
+    - 5000:80
+    build:
+      context: .
+      dockerfile: Dockerfile


### PR DESCRIPTION
Adds a Dockerfile and Docker Compose. Tested it locally and works great. Easy if you don't have dotnet installed. Per the readme:

# Docker

Build with Docker:

```bash
docker build -t vulnerable-core-app .
docker run -d -p 5000:80 --name vulnerable-core-app vulnerable-core-app
```

Alternatively, you can build and run with Docker Compose:

```bash
docker-compose up -d
```